### PR TITLE
createTabButtonを追加し新規タブを開けるようにした( #1 )

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -37,6 +37,18 @@
             </svg>
           </button>
         </div>
+        <!-- 取得したURLをタブで開く -->
+        <div class="createTab">
+          <button title="コピー" id="createTabButton">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-box-arrow-up-right"
+              viewBox="0 0 16 16" aria-label="新規タブで開く">
+              <path
+                d="M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5z" />
+              <path
+                d="M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0v-5z" />
+            </svg>
+          </button>
+        </div>
       </div>
       <!-- 読み取り結果をutf-8やshift-jisに変換できるエンコードボタン-->
       <div class="sub-content">

--- a/popup.html
+++ b/popup.html
@@ -39,7 +39,7 @@
         </div>
         <!-- 取得したURLをタブで開く -->
         <div class="createTab">
-          <button title="コピー" id="createTabButton">
+          <button title="新規タブで開く" id="createTabButton">
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-box-arrow-up-right"
               viewBox="0 0 16 16" aria-label="新規タブで開く">
               <path

--- a/popup.js
+++ b/popup.js
@@ -74,6 +74,32 @@ document.getElementById('copyBtn').addEventListener('click', () => {
   }
 });
 
+// 取得したURLを新規タブで表示
+document.getElementById("createTabButton").addEventListener("click", async () => {
+    const resultText = document.getElementById("result").value;
+
+    if (!resultText) {
+      window.alert("QRコードが読み取られていません。");
+      return;
+    }
+
+    try {
+      const currentTab = await new Promise((resolve, reject) => {
+        chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+          if (tabs.length > 0) {
+            resolve(tabs[0]);
+          } else {
+            reject(new Error("現在のタブを取得できませんでした。"));
+          }
+        });
+      });
+      chrome.tabs.create({ url: resultText, index: currentTab.index + 1 });
+    } catch (err) {
+      console.error("Error :", err);
+      window.alert("新しいタブを開けませんでした。もう一度お試しください。");
+    }
+  });
+
 // ラジオボタンの選択変更イベントリッスン
 document.querySelectorAll('input[name="encoding"]').forEach((radio) => {
   radio.addEventListener('change', updateEncodedData);

--- a/style.css
+++ b/style.css
@@ -51,6 +51,7 @@ body {
 .grid {
   display: grid;
   grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto;
   gap: 1.2em 1em;
   width: 100%;
 }
@@ -68,6 +69,7 @@ body {
 .text {
   font-size: 12px;
   position: relative;
+  grid-row: 1 / 3;
 }
 
 .label-text {
@@ -98,11 +100,11 @@ body {
   font-size: 12px;
 }
 
-.copy {
+.copy, .createTab {
   align-content: center;
 }
 
-#copyBtn {
+#copyBtn, #createTabButton {
   appearance: none;
   -webkit-appearance: none;
   border: 0;
@@ -117,16 +119,16 @@ body {
   align-items: center;
 }
 
-#copyBtn:hover {
+#copyBtn:hover, #createTabButton:hover {
   background-color: #2f22a3;
 }
 
-#copyBtn:focus {
+#copyBtn:focus, #createTabButton:focus {
   outline: none;
   box-shadow: 0 0 0 4px #cbd6ee;
 }
 
-#copyBtn svg {
+#copyBtn svg, #createTabButton svg{
   fill: #fff;
   margin-right: 5px;
   width: 20px;


### PR DESCRIPTION
## 目的
表題の通りです。 #1 のプルリクです。

### 実装したこと
- createTabButtonを設置した
- クリックした際に、QRが読み込まれている場合に、取得されたURLを（現在アクティブなタブの隣に）新規タブで開く
- スタイリングは現状を損なわないよう最小限の追加を行なった

## image
ホバー時
<img width="934" alt="スクリーンショット 2024-06-11 2 19 15" src="https://github.com/teru2teru0/Everyones-QR-Code-Reader/assets/131056197/c494f260-49d7-48b1-87d4-b6abc6f0d34e">

クリック後の遷移（この際、アクティブなタブの隣にタブ作成）
<img width="180" alt="スクリーンショット 2024-06-11 2 19 57" src="https://github.com/teru2teru0/Everyones-QR-Code-Reader/assets/131056197/cbc3df9d-916c-4a66-905d-59a7b2c5f419">
